### PR TITLE
Merge Build/Test Workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master", "nextRelease" ]
+  pull_request:
+    branches: [ "master", "nextRelease" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "master", "nextRelease" ]
+    branches: [ "master", "nextRelease", "workflow" ]
   pull_request:
-    branches: [ "master", "nextRelease" ]
+    branches: [ "master", "nextRelease", "workflow" ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -18,12 +18,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # The first thing we do is checkout the project we are going to build and test.
+    # I do not know all of what this does, so I am leaving it as the first step.
     - uses: actions/checkout@v3
 
-    - name: Configure CMake
+    # We are dependent on ReiserRT_ChripingPhasor. Until we have some sort of build artifact
+    # in place (rpm file), we will just clone, configure, build and install it.
+    # This is acceptable for now and for as long as it remains small and timely.
+    - name: Clone, Configure, Build and Install Dependency
+      run: |
+        cd ..
+        git clone https://github.com/FrankReiser/ReiserRT_FlyingPhasor.git
+        cd ReiserRT_FlyingPhasor
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+        cmake --build . --config ${{env.BUILD_TYPE}}
+        sudo cmake --install .
+        
+    - name: Configure Project Under Test
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: |
+        cd ${{ github.workspace }}
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
@@ -34,4 +52,3 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(
 	ReiserRT_ChirpingPhasor
-	VERSION 1.1.3
+	VERSION 1.1.4
 	DESCRIPTION "ReiserRT Complex Chirping Phasor Tone Generator" )
 
 # Set up compiler requirements

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2022 Frank Reiser
+Copyright (c) 2023 Frank Reiser
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Frank Reiser's C++11 implementation of a fast and accurate, "chirping" sin/cos waveform pair (I/Q) generator.
 This library component is dependent on the ReiserRT_FlyingPhasor shared object library.
+This component has been tested to be interface-able with C++20 compiles.
+Note that the compiled library code is built using the c++11 standard.
 
 ## Overview
 


### PR DESCRIPTION
Our component is dependent upon ReiserRT_FlyingPhasor. GitHub does not yet provide "packages" for C++ library code that we can quickly install. Therefore, we clone, configure, build and install ReiserRT_FlyingPhasor as part of the workflow. Its small and build fast.